### PR TITLE
Add Callout block

### DIFF
--- a/src/Blocks/Callout.php
+++ b/src/Blocks/Callout.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace RehanKanak\LaravelNotionRenderer\Blocks;
+
+class Callout extends Block
+{
+    private function start(): void
+    {
+        $classes = 'border-rounded my-1 text-gray-800 ';
+
+        if ($this->block['callout']['color'] === 'default') {
+            $classes = 'bg-white border border-gray-200 border-solid';
+        } elseif (str_contains($this->block['callout']['color'], '_background')) {
+            $color = str_replace('_background', '', $this->block['callout']['color']);
+
+            $classes .= 'text-black bg-';
+            $classes .= $color !== 'brown' ? $color : 'zinc';
+            $classes .= '-100';
+        } else {
+            $color = $this->block['callout']['color'];
+
+            $classes .= 'bg-white border border-gray-200 border-solid text-';
+            $classes .= $color !== 'brown' ? $color : 'zinc';
+            $classes .= '-700';
+        }
+
+        $this->result .= '<div class="'.$classes.'">';
+        $this->result .= '<div class="flex p-4 pl-3">';
+    }
+
+    public function addIcon(): void
+    {
+        $this->result .= '<div>';
+
+        if ($this->block['callout']['icon']['type'] === 'emoji') {
+            $this->result .= '<div class="flex justify-center items-center h-6 w-6 rounded text-base leading-none">';
+            $this->result .= '<div class="h-4 w-4">';
+            $this->result .= $this->block['callout']['icon']['emoji'];
+            $this->result .= '</div>';
+        } else {
+            $url = $this->block['callout']['icon'][$this->block['callout']['icon']['type']]['url'];
+
+            $this->result .= '<div class="flex justify-center items-center h-6 w-6 rounded">';
+            $this->result .= '<img src="'.$url.'"  class="block w-full h-full border-rounded" />';
+        }
+
+        $this->result .= '</div>';
+        $this->result .= '</div>';
+    }
+
+    private function end(): void
+    {
+        $this->result .= '</div>';
+        $this->result .= '</div>';
+    }
+
+    public function process(): Callout
+    {
+        $this->start();
+
+        $this->addIcon();
+
+        foreach ($this->block['callout']['rich_text'] as $content) {
+            if ($content['text']['link'] !== null) {
+                $this->result .= "<a target='_blank' href=".$content['text']['link']['url'].'>'.$content['text']['content'].'</a>';
+            } else {
+                $this->result .= '<div class="ml-2 px-0.5 whitespace-pre-wrap">';
+                $this->result .= $content['text']['content'];
+                $this->result .= '</div>';
+            }
+        }
+
+        $this->end();
+
+        return $this;
+    }
+
+    public function render(): string
+    {
+        $this->previousBlock = $this->block;
+
+        return $this->result;
+    }
+}

--- a/src/Renderers/NotionRenderer.php
+++ b/src/Renderers/NotionRenderer.php
@@ -2,6 +2,7 @@
 
 namespace RehanKanak\LaravelNotionRenderer\Renderers;
 
+use RehanKanak\LaravelNotionRenderer\Blocks\Callout;
 use RehanKanak\LaravelNotionRenderer\Blocks\Divider;
 use RehanKanak\LaravelNotionRenderer\Blocks\Heading1;
 use RehanKanak\LaravelNotionRenderer\Blocks\Heading2;
@@ -29,6 +30,7 @@ class NotionRenderer
         'heading_3',
         'numbered_list_item',
         'bulleted_list_item',
+        'callout',
         'quote',
         'image',
         'table',
@@ -40,6 +42,7 @@ class NotionRenderer
         'heading_1',
         'heading_2',
         'heading_3',
+        'callout',
         'quote',
         'image',
         'table',
@@ -90,6 +93,12 @@ class NotionRenderer
 
             if ($block['type'] === 'heading_3') {
                 $this->results .= (new Heading3($block, $this->previousBlock))
+                    ->process()
+                    ->render();
+            }
+
+            if ($block['type'] === 'callout') {
+                $this->results .= (new Callout($block, $this->previousBlock))
                     ->process()
                     ->render();
             }


### PR DESCRIPTION
As per issue #2 Implement Callout Block, implemented Callout block rendering. It supports most of the features of callout blocks including rendering emojis, images as icons, background colors, font colors.

# Proof
- Notion: 

![image](https://user-images.githubusercontent.com/81316368/194720427-182dde28-f363-471d-a4b1-5cc78e0851d0.png)

- Rendered Output:

![image](https://user-images.githubusercontent.com/81316368/194720440-48fcf27c-1100-44c2-aac4-9249d7d87aa1.png)
 